### PR TITLE
fix: `cd` handles root directory

### DIFF
--- a/src/commands/cd.cpp
+++ b/src/commands/cd.cpp
@@ -32,7 +32,7 @@ int cmds::cd(const std::vector<std::string>& arg, StreamManager& stream_manager,
     std::string_view path = arg[1];
 
     if(path[0] == '/'){
-        current_path = current_path.root_directory();
+        current_path = current_path.root_path();
     }
 
     for (size_t i = 0; i < path.size();) {


### PR DESCRIPTION
`root_path` returns a full path to the root directory rather than `root_directory`, which doesn't return the root name. Though Windows is no longer supported, and Unix has no a root name; this makes the intention more clearer.