### PR TITLE
Fix function command argument handling

### DIFF
--- a/src/commands/function.cpp
+++ b/src/commands/function.cpp
@@ -1,16 +1,24 @@
 #include <iostream>
 #include <vector>
 
+#include "fmt/format.h"
 #include "shell.h"
 
 int Shell::cmd_function(const std::vector<std::string>& arg) {
+    if (arg.size() < 3) {
+        fmt::print(stderr, "Argument size error.\n");
+        return 1;
+    }
+
     std::string function_content;
     for (std::size_t i = 2; i < arg.size(); ++i) {
         function_content += arg[i];
         function_content += ' ';
     }
 
-    function_content.pop_back();
+    if (!function_content.empty()) {
+        function_content.pop_back();
+    }
 
     this->functions.set(arg[1], function_content);
 

--- a/test/shell.test.cpp
+++ b/test/shell.test.cpp
@@ -2,4 +2,12 @@
 
 #include "gtest/gtest.h"
 
+Shell shell;
+
 TEST(Shell, run) { EXPECT_EQ(1, 1); }
+
+TEST(Shell, function_requires_body) {
+    Command cmd("function foo");
+    cmd.parse();
+    EXPECT_NE(shell.exec_cmd(cmd), 0);
+}


### PR DESCRIPTION
## Summary
- handle missing arguments in the `function` builtin
- add regression test

## Testing
- `cmake -DBUILD_TESTING=ON .. && make -j $(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684192af01b88327959b7dfb00d09eeb