### PR TITLE
fix typo in init script

### DIFF
--- a/etc/init.yush
+++ b/etc/init.yush
@@ -40,4 +40,4 @@ alias '...' 'cd ../..'
 # customize your shell under here
 
 echo "Welcome to yush!"
-echo "edit ~/.yushrc or ~/.config/yush/confifg.yush to customize your shell"
+echo "edit ~/.yushrc or ~/.config/yush/config.yush to customize your shell"


### PR DESCRIPTION
## Summary
- fix a typo in the init script welcome message

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841954726f0832784c007f080df5a0b