### PR TITLE
Fix cd path logic

### DIFF
--- a/src/commands/cd.cpp
+++ b/src/commands/cd.cpp
@@ -15,13 +15,16 @@ static int cd_single(std::string_view path, std::filesystem::path& current_path,
     } else if (path == "~") {
         current_path = vars.get("HOME");
         return 0;
-    } else if (std::filesystem::is_directory(current_path.append(path))) {
-        return 0;
-    } else {
-        fmt::print(stderr, "cd: {} is not a directory.\n", path);
-        return 1;
     }
-    return 0;
+
+    std::filesystem::path new_path = current_path / std::string(path);
+    if (std::filesystem::is_directory(new_path)) {
+        current_path = new_path;
+        return 0;
+    }
+
+    fmt::print(stderr, "cd: {} is not a directory.\n", path);
+    return 1;
 }
 
 int Shell::cmd_cd(const std::vector<std::string>& arg) {


### PR DESCRIPTION
## Summary
- correct `cd` path handling to avoid corrupting current directory when invalid paths are provided

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68427da79e888327854e5fe9988505c6